### PR TITLE
Changed resource link for react router

### DIFF
--- a/src/main/ui/index.ejs
+++ b/src/main/ui/index.ejs
@@ -7,7 +7,7 @@
     <script type="text/javascript" id="globalnav-script" src="https://id.openmrs.org/globalnav/js/app-optimized.js"></script>
     <script src="https://unpkg.com/react@15/dist/react.min.js"></script>
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.min.js"></script>
-    <script src="https://unpkg.com/react-router/umd/ReactRouter.min.js"></script>
+    <script src="https://unpkg.com/react-router/umd/react-router.min.js"></script>
     <script src="https://use.fontawesome.com/75c2bbc0c8.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The older link caused the site to be unable to fetch the react router.js file. This commit basically updates the old broken link.