### PR TITLE
Fix ui build (requires webpack ~2.2.0 and node 5.x on Windows)

### DIFF
--- a/src/main/ui/package.json
+++ b/src/main/ui/package.json
@@ -8,6 +8,9 @@
     "build:prod": "webpack --env=prod -p --config webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "engines": {
+    "node": "^5.3.0"
+  },
   "keywords": [
     "OpenMRS"
   ],
@@ -34,6 +37,6 @@
     "node-sass": "^4.5.0",
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
-    "webpack": "^2.2.0"
+    "webpack": "~2.2.0"
   }
 }


### PR DESCRIPTION
Fixes the following errors when calling npm run build:dev

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module.rules[0].exclude: The provided value "node_modules" is not an absolute path!
 - configuration.output.path: The provided value "../resources/static" is not an absolute path!
```

and

```
ERROR in ./~/css-loader!./~/sass-loader!./app/sass/addonindex.scss
    Module build failed: Error: Missing binding c:\Users\Rafal\Workspace\openmrs-contrib-addonindex\src\main\ui\node_modules\node-sass\vendor\win32-x64-48\binding.node
    Node Sass could not find a binding for your current environment: Windows 64-bit with Node.js 6.x

    Found bindings for the following environments:
      - Windows 64-bit with Node.js 5.x
```

Note engines is not really enforced, but it serves as a recommendation for a developer.