### PR TITLE
Add Order Entry UI module to addon index list

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -2307,6 +2307,22 @@
       }
     },
     {
+      "uid": "org.openmrs.module.orderentryui",
+      "type": "OMOD",
+      "name": "Order Entry UI",
+      "maintainers": [
+        {
+          "name": "Daniel Kayiwa"
+        }
+      ],
+      "backend": "org.openmrs.addonindex.backend.Bintray",
+      "bintrayPackageDetails": {
+        "owner": "openmrs",
+        "repo": "omod",
+        "package": "orderentryui"
+      }
+    },
+    {
       "uid": "org.openmrs.module.orderextension",
       "type": "OMOD",
       "name": "Order Extension",


### PR DESCRIPTION
**SUMMARY**
Add Order Entry UI Module to addon index list

Check [here](https://github.com/openmrs/openmrs-module-orderentryui) for more information about the Order Entry UI Module

**Note:** This module is required by the Order Entry UI OWA