### PR TITLE
Added Location based access control to the AddOn index list

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -1775,6 +1775,28 @@
       }
     },
     {
+      "uid": "org.openmrs.module.locationbasedaccess",
+      "type": "OMOD",
+      "name": "Location Based Access Control",
+      "tags": [
+        "location", "accesscontrol"
+      ],
+      "maintainers": [
+        {
+          "name": "Daniel Kayiwa"
+        },
+        {
+          "name": "K.Suthagar"
+        }
+      ],
+      "backend": "org.openmrs.addonindex.backend.Bintray",
+      "bintrayPackageDetails": {
+        "owner": "openmrs",
+        "repo": "omod",
+        "package": "locationbasedaccess"
+      }
+    },
+    {
       "uid": "org.openmrs.module.logic",
       "type": "OMOD",
       "name": "Logic",


### PR DESCRIPTION
This PR created to add the location based access control module to the AddOn index listing. The very first version of this module can be found here : https://bintray.com/openmrs/omod/locationbasedaccess/0.1.0-beta

