### PR TITLE
AO-20: Created a list of RefApp 2.9 modules (as of Oct 30, 2018)

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -4649,7 +4649,186 @@
         }
       ]
     },
-{
+    {
+      "uid": "refapp_2_8",
+      "name": "RefApp 2.8",
+      "description": "Included in Reference Application 2.8",
+      "addOns": [
+        {
+          "uid": "org.openmrs.module.addresshierarchy",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.admin-ui-module",
+          "version": "1.2.3"
+        },
+        {
+          "uid": "org.openmrs.module.allergy-ui-module",
+          "version": "1.8.1"
+        },
+        {
+          "uid": "org.openmrs.module.appframework",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointmentscheduling",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.appui",
+          "version": "1.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.atlas",
+          "version": "2.2"
+        },
+        {
+          "uid": "org.openmrs.module.calculation",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.chart-search-module",
+          "version": "2.1.0"
+        },
+        {
+          "uid": "org.openmrs.module.core-apps-module",
+          "version": "1.19.0"
+        },
+        {
+          "uid": "org.openmrs.module.data-exchange-module",
+          "version": "1.3.2"
+        },
+        {
+          "uid": "org.openmrs.module.emrapi",
+          "version": "1.24.4"
+        },
+        {
+          "uid": "org.openmrs.module.event",
+          "version": "2.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.openmrs-fhir-module",
+          "version": "1.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.form-entry-app-module",
+          "version": "1.4.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentry",
+          "version": "3.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentryui",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlwidgets",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.idgen",
+          "version": "4.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.legacy-ui-module",
+          "version": "1.4.0"
+        },
+        {
+          "uid": "org.openmrs.module.logic",
+          "version": "0.5.2"
+        },
+        {
+          "uid": "org.openmrs.module.metadatadeploy",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatamapping",
+          "version": "1.3.4"
+        },
+        {
+          "uid": "org.openmrs.module.metadatasharing",
+          "version": "1.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.namephonetics",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.open-web-apps-module",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.providermanagement",
+          "version": "2.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-application-module",
+          "version": "2.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-demo-data-module",
+          "version": "1.4.4"
+        },
+        {
+          "uid": "org.openmrs.module.reference-metadata-module",
+          "version": "2.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-app-module",
+          "version": "1.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-core-module",
+          "version": "1.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting",
+          "version": "1.16.0"
+        },
+        {
+          "uid": "org.openmrs.module.reportingcompatibility",
+          "version": "2.0.5"
+        },
+        {
+          "uid": "org.openmrs.module.reportingrest",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting-ui-module",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.serialization-xstream",
+          "version": "0.2.14"
+        },
+        {
+          "uid": "org.openmrs.owa.sysadmin",
+          "version": "1.1"
+        },
+        {
+          "uid": "org.openmrs.module.uicommons",
+          "version": "2.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.uiframework",
+          "version": "3.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.uilibrary",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.webservices-rest",
+          "version": "2.22.0"
+        }
+      ]
+    },
+    {
       "uid": "refapp_2_7",
       "name": "RefApp 2.7",
       "description": "Included in Reference Application 2.7",
@@ -4810,10 +4989,8 @@
           "uid": "org.openmrs.module.open-web-apps-module",
           "version": "1.8.1"
         }
-
       ]
-    }
-,
+    },
     {
       "uid": "refapp_2_6",
       "name": "RefApp 2.6",
@@ -4975,7 +5152,6 @@
           "uid": "org.openmrs.module.open-web-apps-module",
           "version": "1.7.0"
         }
-
       ]
     }
   ]

--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -4650,6 +4650,181 @@
       ]
     },
     {
+      "uid": "refapp_2_9",
+      "name": "RefApp 2.9",
+      "description": "Included in Reference Application 2.9",
+      "addOns": [
+        {
+          "uid": "org.openmrs.module.addresshierarchy",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.admin-ui-module",
+          "version": "1.2.4"
+        },
+        {
+          "uid": "org.openmrs.module.allergy-ui-module",
+          "version": "1.8.1"
+        },
+        {
+          "uid": "org.openmrs.module.appframework",
+          "version": "2.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointmentscheduling",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.atlas",
+          "version": "2.2"
+        },
+        {
+          "uid": "org.openmrs.module.calculation",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.chart-search-module",
+          "version": "2.1.0"
+        },
+        {
+          "uid": "org.openmrs.module.core-apps-module",
+          "version": "1.20.0"
+        },
+        {
+          "uid": "org.openmrs.module.data-exchange-module",
+          "version": "1.3.2"
+        },
+        {
+          "uid": "org.openmrs.module.emrapi",
+          "version": "1.24.5"
+        },
+        {
+          "uid": "org.openmrs.module.event",
+          "version": "2.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.openmrs-fhir-module",
+          "version": "1.14.0"
+        },
+        {
+          "uid": "org.openmrs.module.form-entry-app-module",
+          "version": "1.4.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentry",
+          "version": "3.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentryui",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlwidgets",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.idgen",
+          "version": "4.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.legacy-ui-module",
+          "version": "1.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.logic",
+          "version": "0.5.2"
+        },
+        {
+          "uid": "org.openmrs.module.metadatadeploy",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatamapping",
+          "version": "1.3.4"
+        },
+        {
+          "uid": "org.openmrs.module.metadatasharing",
+          "version": "1.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.namephonetics",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.open-web-apps-module",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.providermanagement",
+          "version": "2.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-application-module",
+          "version": "2.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-demo-data-module",
+          "version": "1.4.4"
+        },
+        {
+          "uid": "org.openmrs.module.reference-metadata-module",
+          "version": "2.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-app-module",
+          "version": "1.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-core-module",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting",
+          "version": "1.17.0"
+        },
+        {
+          "uid": "org.openmrs.module.reportingcompatibility",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.reportingrest",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting-ui-module",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.serialization-xstream",
+          "version": "0.2.14"
+        },
+        {
+          "uid": "org.openmrs.owa.sysadmin",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.uicommons",
+          "version": "2.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.uiframework",
+          "version": "3.14.0"
+        },
+        {
+          "uid": "org.openmrs.module.uilibrary",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.webservices-rest",
+          "version": "2.23.0"
+        }
+      ]
+    },
+    {
       "uid": "refapp_2_8",
       "name": "RefApp 2.8",
       "description": "Included in Reference Application 2.8",


### PR DESCRIPTION
***Do not merge before the release of RefApp 2.9***

## Description of what I changed
I've added a list of RefApp 2.9 modules to the addons index as of Oct 30, 2018.

## Issue I worked on
see https://issues.openmrs.org/browse/AO-20

Link to the task instance:
https://codein.withgoogle.com/dashboard/task-instances/6142415594323968/

## Notes
I have used this wiki page as the source for the list:https://wiki.openmrs.org/display/RES/Release+Notes+2.9.0

**I did not list UI Test Framework 2.3.0, as it is not available on https://om.rs/addons**
**I have assumed that the version of the HTML Form Entry UI is 1.7.0 (there's a typo on the wiki page)**