### PR TITLE
AO-18: Updated links for 17 modules

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -14,6 +14,17 @@
           "url": "https://github.com/openmrs"
         }
       ],
+            "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Concept+Dictionary+Basics",
+          "title": "Concept Dictionary Basics"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/rkorytkowski/openmrs-owa-conceptdictionary"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -33,6 +44,17 @@
         {
           "name": "OpenMRS",
           "url": "https://github.com/openmrs"
+        }
+      ],
+        "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/projects/Cohort+Module",
+          "title": "Cohort Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-cohortbuilder"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -88,6 +110,17 @@
           "url": "https://github.com/openmrs"
         }
       ],
+        "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Addon+Manager+Open+Web+App",
+          "title": "Addon Manager Open Web App"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-addonmanager"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -103,6 +136,17 @@
         {
           "name": "Andela apprentices",
           "url": "https://andela.com/"
+        }
+      ],
+        "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/projects/Order+Entry+Module+Design",
+          "title": "Order Entry Module Design"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-owa-orderentry"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -123,6 +167,17 @@
         {
           "name": "K.Suthagar",
           "url": "https://talk.openmrs.org/u/suthagar23"
+        }
+      ],      
+        "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/System+Administration+OWA",
+          "title": "System Administration OWA"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-owa-sysadmin"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -246,6 +301,17 @@
         },
         {
           "name": "Darius Jazayeri"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/App+Framework+Developer+Documentation",
+          "title": "App Framework Developer Documentation"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-appframework"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -375,6 +441,17 @@
           "name": "Darius Jazayeri"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Atlas+Module",
+          "title": "Atlas Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-atlas"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -389,6 +466,17 @@
       "maintainers": [
         {
           "name": "Ben Wolfe"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Atom+Feed+Module",
+          "title": "Atom Feed Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-atomfeed"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -461,6 +549,17 @@
         },
         {
           "name": "Daniel Kayiwa"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Calculation+Module",
+          "title": "Calculation Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-calculation"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -591,6 +690,17 @@
           "name": "jenn"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Concept+Management+Apps+Documentation",
+          "title": "Concept Management Apps Documentation"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-conceptmanagementapps"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -653,6 +763,17 @@
           "name": "Saptarshi Purkayastha"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Custom+Branding+Module",
+          "title": "Custom Branding Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-custombranding"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -675,6 +796,17 @@
           "name": "bmamlin"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Custom+Messages+Module",
+          "title": "Custom Messages"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-custommessage"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -689,6 +821,17 @@
       "maintainers": [
         {
           "name": "Joaquin Blaya"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Dashboard+Frame",
+          "title": "Dashboard Frame"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-dashboardframe"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -720,6 +863,17 @@
         },
         {
           "name": "Daniel Kayiwa"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Database+Backup+Module",
+          "title": "Database Backup Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-databasebackup"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -802,6 +956,17 @@
           "name": "Daniel Kayiwa"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Data+Entry+Statistics",
+          "title": "Data Entry Statistics"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-dataentrystatistics"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -829,6 +994,18 @@
         },
         {
           "name": "Daniel Kayiwa"
+        }
+      ],
+      
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Data+Integrity+Module",
+          "title": "Data Integrity Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-dataintegrity"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
@@ -956,6 +1133,17 @@
           "name": "Daniel Kayiwa"
         }
       ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/EMR+API+Module",
+          "title": "EMR API Module"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-emrapi"
+        }
+      ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
         "owner": "openmrs",
@@ -996,6 +1184,21 @@
         },
         {
           "name": "Darius Jazayeri"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Event+Module",
+<<<<<<< HEAD
+          "title": "Event Module"
+=======
+          "title": "OpenMRS Wiki"
+>>>>>>> 515193662898f9228142f136d42d9be2081937e7
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-event"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",


### PR DESCRIPTION
I decided commiting when I reach line 1000 (numbering before adding any links, so came to line 1199 after changes) might be a good start. However, I could only do 17 modules as I couldn't find links for the source/documentation or they were marked INACTIVE or DEPRECATED
https://github.com/openmrs/openmrs-contrib-addonindex/pull/issue