### PR TITLE
Adding Common Lab Module

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -802,18 +802,13 @@
           "title": "Wiki Page"
         },
         {
-          "rel": "documentation",
-          "href": "https://wiki.openmrs.org/display/docs/Common+Lab+Module+Rest+API",
-          "title": "REST API"
-        },
-        {
           "rel": "source",
           "href": "https://github.com/openmrs/openmrs-module-commonlabtest"
         }
       ],
       "backend": "org.openmrs.addonindex.backend.Bintray",
       "bintrayPackageDetails": {
-        "owner": "seekme94",
+        "owner": "openmrs",
         "repo": "omod",
         "package": "commonlabtest"
       }

--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -784,6 +784,41 @@
       }
     },
     {
+      "uid": "org.openmrs.module.commonlabtest",
+      "type": "OMOD",
+      "name": "Common Lab Test",
+      "maintainers": [
+        {
+          "name": "Owais Hussain"
+        },
+        {
+          "name": "Tahira Niazi"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Common+Lab+Module",
+          "title": "Wiki Page"
+        },
+        {
+          "rel": "documentation",
+          "href": "https://wiki.openmrs.org/display/docs/Common+Lab+Module+Rest+API",
+          "title": "REST API"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/openmrs/openmrs-module-commonlabtest"
+        }
+      ],
+      "backend": "org.openmrs.addonindex.backend.Bintray",
+      "bintrayPackageDetails": {
+        "owner": "seekme94",
+        "repo": "omod",
+        "package": "commonlabtest"
+      }
+    },
+    {
       "uid": "org.openmrs.module.comparelists",
       "status": "INACTIVE",
       "type": "OMOD",


### PR DESCRIPTION
I have followed the [module release guide](https://wiki.openmrs.org/display/docs/Module+Release) on Wiki. I can see a published version on Bintray.
At present, this module is parked in my Bintray account, but in the future will be managed under OpenMRS.