### PR TITLE
AO-26A: Create list of Ref App 2.10 and RefApp 2.11.0 modules for AddOns

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -6751,6 +6751,523 @@
       ]
     },
     {
+      "uid": "refapp_2.11",
+      "name": "RefApp 2.11",
+      "description": "Included in Reference Application 2.11",
+      "addOns": [
+        {
+          "uid": "org.openmrs.module.addresshierarchy",
+          "version": "2.14.2"
+        },
+        {
+          "uid": "org.openmrs.module.admin-ui-module",
+          "version": "1.4.0"
+        },
+        {
+          "uid": "org.openmrs.module.allergy-ui-module",
+          "version": "1.8.3"
+        },
+        {
+          "uid": "org.openmrs.module.appframework",
+          "version": "2.16.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointmentscheduling",
+          "version": "1.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.atlas",
+          "version": "2.2.4"
+        },
+        {
+          "uid": "org.openmrs.module.attachments",
+          "version": "2.4.0"
+        },
+        {
+          "uid": "org.openmrs.module.calculation",
+          "version": "1.2.1"
+        },
+        {
+          "uid": "org.openmrs.module.core-apps-module",
+          "version": "1.31.0"
+        },
+        {
+          "uid": "org.openmrs.module.data-exchange-module",
+          "version": "1.3.6"
+        },
+        {
+          "uid": "org.openmrs.module.emrapi",
+          "version": "1.30.0"
+        },
+        {
+          "uid": "org.openmrs.module.event",
+          "version": "2.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.openmrs-fhir2-module",
+          "version": "1.1.0"
+        },
+        {
+          "uid": "org.openmrs.module.form-entry-app-module",
+          "version": "1.4.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentry",
+          "version": "3.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentryui",
+          "version": "1.11.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlwidgets",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.idgen",
+          "version": "4.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.legacy-ui-module",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatadeploy",
+          "version": "1.12.1"
+        },
+        {
+          "uid": "org.openmrs.module.metadatamapping",
+          "version": "1.3.5"
+        },
+        {
+          "uid": "org.openmrs.module.metadatasharing",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.open-web-apps-module",
+          "version": "1.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.providermanagement",
+          "version": "2.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.appui",
+          "version": "1.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-application-module",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-demo-data-module",
+          "version": "1.4.6"
+        },
+        {
+          "uid": "org.openmrs.module.reference-metadata-module",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-app-module",
+          "version": "1.20.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-core-module",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting",
+          "version": "1.21.0"
+        },
+        {
+          "uid": "org.openmrs.module.reportingcompatibility",
+          "version": "2.0.7"
+        },
+        {
+          "uid": "org.openmrs.module.reportingrest",
+          "version": "1.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting-ui-module",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.serialization-xstream",
+          "version": "0.2.14"
+        },
+        {
+          "uid": "org.openmrs.module.uicommons",
+          "version": "2.15.0"
+        },
+         {
+          "uid": "org.openmrs.owa.sysadmin",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.uiframework",
+          "version": "3.19.0"
+        },
+        {
+          "uid": "org.openmrs.module.uilibrary",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.webservices-rest",
+          "version": "2.29.0"
+        }
+      ]
+    },
+    {
+      "uid": "refapp_2.10",
+      "name": "RefApp 2.10",
+      "description": "Included in Reference Application 2.10",
+      "addOns": [
+        {
+          "uid": "org.openmrs.module.addresshierarchy",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.admin-ui-module",
+          "version": "1.3.0"
+        },
+        {
+          "uid": "org.openmrs.module.allergy-ui-module",
+          "version": "1.8.2"
+        },
+        {
+          "uid": "org.openmrs.module.appframework",
+          "version": "2.14.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointmentscheduling",
+          "version": "1.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.atlas",
+          "version": "2.2"
+        },
+        {
+          "uid": "org.openmrs.module.attachments",
+          "version": "2.2.0"
+        },
+        {
+          "uid": "org.openmrs.module.calculation",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.core-apps-module",
+          "version": "1.28.0"
+        },
+        {
+          "uid": "org.openmrs.module.data-exchange-module",
+          "version": "1.3.4"
+        },
+        {
+          "uid": "org.openmrs.module.emrapi",
+          "version": "1.28.0"
+        },
+        {
+          "uid": "org.openmrs.module.event",
+          "version": "2.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.openmrs-fhir-module",
+          "version": "1.20.0"
+        },
+        {
+          "uid": "org.openmrs.module.form-entry-app-module",
+          "version": "1.4.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentry",
+          "version": "3.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentryui",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlwidgets",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.idgen",
+          "version": "4.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.legacy-ui-module",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatadeploy",
+          "version": "1.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatamapping",
+          "version": "1.3.4"
+        },
+        {
+          "uid": "org.openmrs.module.metadatasharing",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.open-web-apps-module",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.providermanagement",
+          "version": "2.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.appui",
+          "version": "1.12.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-application-module",
+          "version": "2.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-demo-data-module",
+          "version": "1.4.5"
+        },
+        {
+          "uid": "org.openmrs.module.reference-metadata-module",
+          "version": "2.10.2"
+        },
+        {
+          "uid": "org.openmrs.module.registration-app-module",
+          "version": "1.16.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-core-module",
+          "version": "1.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting",
+          "version": "1.20.0"
+        },
+        {
+          "uid": "org.openmrs.module.reportingcompatibility",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.reportingrest",
+          "version": "1.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting-ui-module",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.serialization-xstream",
+          "version": "0.2.14"
+        },
+        {
+          "uid": "org.openmrs.module.uicommons",
+          "version": "2.12.0"
+        },
+         {
+          "uid": "org.openmrs.owa.sysadmin",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.uiframework",
+          "version": "3.17.0"
+        },
+        {
+          "uid": "org.openmrs.module.uilibrary",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.webservices-rest",
+          "version": "2.28.0"
+        }
+      ]
+    },
+    {
+      "uid": "refapp_2_9",
+      "name": "RefApp 2.9",
+      "description": "Included in Reference Application 2.9",
+      "addOns": [
+        {
+          "uid": "org.openmrs.module.addresshierarchy",
+          "version": "2.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.admin-ui-module",
+          "version": "1.2.4"
+        },
+        {
+          "uid": "org.openmrs.module.allergy-ui-module",
+          "version": "1.8.1"
+        },
+        {
+          "uid": "org.openmrs.module.appframework",
+          "version": "2.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointmentscheduling",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.atlas",
+          "version": "2.2"
+        },
+        {
+          "uid": "org.openmrs.module.attachments",
+          "version": "2.1.0"
+        },
+        {
+          "uid": "org.openmrs.module.calculation",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.chart-search-module",
+          "version": "2.1.0"
+        },
+        {
+          "uid": "org.openmrs.module.core-apps-module",
+          "version": "1.21.0"
+        },
+        {
+          "uid": "org.openmrs.module.data-exchange-module",
+          "version": "1.3.3"
+        },
+        {
+          "uid": "org.openmrs.module.emrapi",
+          "version": "1.27.0"
+        },
+        {
+          "uid": "org.openmrs.module.event",
+          "version": "2.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.openmrs-fhir-module",
+          "version": "1.18.0"
+        },
+        {
+          "uid": "org.openmrs.module.form-entry-app-module",
+          "version": "1.4.2"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentry",
+          "version": "3.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlformentryui",
+          "version": "1.7.0"
+        },
+        {
+          "uid": "org.openmrs.module.htmlwidgets",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.idgen",
+          "version": "4.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.legacy-ui-module",
+          "version": "1.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatadeploy",
+          "version": "1.11.0"
+        },
+        {
+          "uid": "org.openmrs.module.metadatamapping",
+          "version": "1.3.4"
+        },
+        {
+          "uid": "org.openmrs.module.metadatasharing",
+          "version": "1.5.0"
+        },
+        {
+          "uid": "org.openmrs.module.namephonetics",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.open-web-apps-module",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.providermanagement",
+          "version": "2.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-application-module",
+          "version": "2.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.reference-demo-data-module",
+          "version": "1.4.4"
+        },
+        {
+          "uid": "org.openmrs.module.reference-metadata-module",
+          "version": "2.9.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-app-module",
+          "version": "1.13.0"
+        },
+        {
+          "uid": "org.openmrs.module.registration-core-module",
+          "version": "1.8.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting",
+          "version": "1.17.0"
+        },
+        {
+          "uid": "org.openmrs.module.reportingcompatibility",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.reportingrest",
+          "version": "1.10.0"
+        },
+        {
+          "uid": "org.openmrs.module.reporting-ui-module",
+          "version": "1.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.serialization-xstream",
+          "version": "0.2.14"
+        },
+        {
+          "uid": "org.openmrs.owa.sysadmin",
+          "version": "1.2"
+        },
+        {
+          "uid": "org.openmrs.module.uicommons",
+          "version": "2.6.0"
+        },
+        {
+          "uid": "org.openmrs.module.uiframework",
+          "version": "3.15.0"
+        },
+        {
+          "uid": "org.openmrs.module.uilibrary",
+          "version": "2.0.6"
+        },
+        {
+          "uid": "org.openmrs.module.webservices-rest",
+          "version": "2.24.0"
+        }
+      ]
+    },
+    {
         "uid": "refapp_2.10",
         "name": "RefApp 2.10",
         "description": "Included in Reference Application 2.10",

--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -6751,176 +6751,176 @@
       ]
     },
     {
-      "uid": "refapp_2.10",
-      "name": "RefApp 2.10",
-      "description": "Included in Reference Application 2.10",
-      "addOns": [
-        {
-          "uid": "org.openmrs.module.addresshierarchy",
-          "version": "2.11.0"
-        },
-        {
-          "uid": "org.openmrs.module.admin-ui-module",
-          "version": "1.3.0"
-        },
-        {
-          "uid": "org.openmrs.module.allergy-ui-module",
-          "version": "1.8.2"
-        },
-        {
-          "uid": "org.openmrs.module.appframework",
-          "version": "2.14.0"
-        },
-        {
-          "uid": "org.openmrs.module.appointmentscheduling",
-          "version": "1.12.0"
-        },
-        {
-          "uid": "org.openmrs.module.appointment-scheduling-ui-module",
-          "version": "1.9.0"
-        },
-        {
-          "uid": "org.openmrs.module.atlas",
-          "version": "2.2"
-        },
-        {
-          "uid": "org.openmrs.module.attachments",
-          "version": "2.2.0"
-        },
-        {
-          "uid": "org.openmrs.module.calculation",
-          "version": "1.2"
-        },
-        {
-          "uid": "org.openmrs.module.core-apps-module",
-          "version": "1.28.0"
-        },
-        {
-          "uid": "org.openmrs.module.data-exchange-module",
-          "version": "1.3.4"
-        },
-        {
-          "uid": "org.openmrs.module.emrapi",
-          "version": "1.28.0"
-        },
-        {
-          "uid": "org.openmrs.module.event",
-          "version": "2.7.0"
-        },
-        {
-          "uid": "org.openmrs.module.openmrs-fhir-module",
-          "version": "1.20.0"
-        },
-        {
-          "uid": "org.openmrs.module.form-entry-app-module",
-          "version": "1.4.2"
-        },
-        {
-          "uid": "org.openmrs.module.htmlformentry",
-          "version": "3.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.htmlformentryui",
-          "version": "1.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.htmlwidgets",
-          "version": "1.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.idgen",
-          "version": "4.5.0"
-        },
-        {
-          "uid": "org.openmrs.module.legacy-ui-module",
-          "version": "1.6.0"
-        },
-        {
-          "uid": "org.openmrs.module.metadatadeploy",
-          "version": "1.11.0"
-        },
-        {
-          "uid": "org.openmrs.module.metadatamapping",
-          "version": "1.3.4"
-        },
-        {
-          "uid": "org.openmrs.module.metadatasharing",
-          "version": "1.6.0"
-        },
-        {
-          "uid": "org.openmrs.module.open-web-apps-module",
-          "version": "1.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.providermanagement",
-          "version": "2.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.appui",
-          "version": "1.12.0"
-        },
-        {
-          "uid": "org.openmrs.module.reference-application-module",
-          "version": "2.10.0"
-        },
-        {
-          "uid": "org.openmrs.module.reference-demo-data-module",
-          "version": "1.4.5"
-        },
-        {
-          "uid": "org.openmrs.module.reference-metadata-module",
-          "version": "2.10.2"
-        },
-        {
-          "uid": "org.openmrs.module.registration-app-module",
-          "version": "1.16.0"
-        },
-        {
-          "uid": "org.openmrs.module.registration-core-module",
-          "version": "1.9.0"
-        },
-        {
-          "uid": "org.openmrs.module.reporting",
-          "version": "1.20.0"
-        },
-        {
-          "uid": "org.openmrs.module.reportingcompatibility",
-          "version": "2.0.6"
-        },
-        {
-          "uid": "org.openmrs.module.reportingrest",
-          "version": "1.11.0"
-        },
-        {
-          "uid": "org.openmrs.module.reporting-ui-module",
-          "version": "1.6.0"
-        },
-        {
-          "uid": "org.openmrs.module.serialization-xstream",
-          "version": "0.2.14"
-        },
-        {
-          "uid": "org.openmrs.module.uicommons",
-          "version": "2.12.0"
-        },
-         {
-          "uid": "org.openmrs.owa.sysadmin",
-          "version": "1.2"
-        },
-        {
-          "uid": "org.openmrs.module.uiframework",
-          "version": "3.17.0"
-        },
-        {
-          "uid": "org.openmrs.module.uilibrary",
-          "version": "2.0.6"
-        },
-        {
-          "uid": "org.openmrs.module.webservices-rest",
-          "version": "2.28.0"
-        }
-      ]
-    },
+        "uid": "refapp_2.10",
+        "name": "RefApp 2.10",
+        "description": "Included in Reference Application 2.10",
+        "addOns": [
+          {
+            "uid": "org.openmrs.module.addresshierarchy",
+            "version": "2.14.2"
+          },
+          {
+            "uid": "org.openmrs.module.admin-ui-module",
+            "version": "1.3.0"
+          },
+          {
+            "uid": "org.openmrs.module.allergy-ui-module",
+            "version": "1.8.3"
+          },
+          {
+            "uid": "org.openmrs.module.appframework",
+            "version": "2.16.0"
+          },
+          {
+            "uid": "org.openmrs.module.appointmentscheduling",
+            "version": "1.13.0"
+          },
+          {
+            "uid": "org.openmrs.module.appointment-scheduling-ui-module",
+            "version": "1.9.0"
+          },
+          {
+            "uid": "org.openmrs.module.atlas",
+            "version": "2.2.4"
+          },
+          {
+            "uid": "org.openmrs.module.attachments",
+            "version": "2.4.0"
+          },
+          {
+            "uid": "org.openmrs.module.calculation",
+            "version": "1.2.1"
+          },
+          {
+            "uid": "org.openmrs.module.core-apps-module",
+            "version": "1.31.0"
+          },
+          {
+            "uid": "org.openmrs.module.data-exchange-module",
+            "version": "1.3.6"
+          },
+          {
+            "uid": "org.openmrs.module.emrapi",
+            "version": "1.30.0"
+          },
+          {
+            "uid": "org.openmrs.module.event",
+            "version": "2.8.0"
+          },
+          {
+            "uid": "org.openmrs.module.openmrs-fhir2-module",
+            "version": "1.1.0"
+          },
+          {
+            "uid": "org.openmrs.module.form-entry-app-module",
+            "version": "1.4.2"
+          },
+          {
+            "uid": "org.openmrs.module.htmlformentry",
+            "version": "3.12.0"
+          },
+          {
+            "uid": "org.openmrs.module.htmlformentryui",
+            "version": "1.11.2"
+          },
+          {
+            "uid": "org.openmrs.module.htmlwidgets",
+            "version": "1.10.0"
+          },
+          {
+            "uid": "org.openmrs.module.idgen",
+            "version": "4.6.0"
+          },
+          {
+            "uid": "org.openmrs.module.legacy-ui-module",
+            "version": "1.7.0"
+          },
+          {
+            "uid": "org.openmrs.module.metadatadeploy",
+            "version": "1.12.1"
+          },
+          {
+            "uid": "org.openmrs.module.metadatamapping",
+            "version": "1.3.5"
+          },
+          {
+            "uid": "org.openmrs.module.metadatasharing",
+            "version": "1.7.0"
+          },
+          {
+            "uid": "org.openmrs.module.open-web-apps-module",
+            "version": "1.12.0"
+          },
+          {
+            "uid": "org.openmrs.module.providermanagement",
+            "version": "2.12.0"
+          },
+          {
+            "uid": "org.openmrs.module.appui",
+            "version": "1.13.0"
+          },
+          {
+            "uid": "org.openmrs.module.reference-application-module",
+            "version": "2.11.0"
+          },
+          {
+            "uid": "org.openmrs.module.reference-demo-data-module",
+            "version": "1.4.6"
+          },
+          {
+            "uid": "org.openmrs.module.reference-metadata-module",
+            "version": "2.11.0"
+          },
+          {
+            "uid": "org.openmrs.module.registration-app-module",
+            "version": "1.20.0"
+          },
+          {
+            "uid": "org.openmrs.module.registration-core-module",
+            "version": "1.10.0"
+          },
+          {
+            "uid": "org.openmrs.module.reporting",
+            "version": "1.21.0"
+          },
+          {
+            "uid": "org.openmrs.module.reportingcompatibility",
+            "version": "2.0.7"
+          },
+          {
+            "uid": "org.openmrs.module.reportingrest",
+            "version": "1.11.0"
+          },
+          {
+            "uid": "org.openmrs.module.reporting-ui-module",
+            "version": "1.7.0"
+          },
+          {
+            "uid": "org.openmrs.module.serialization-xstream",
+            "version": "0.2.14"
+          },
+          {
+            "uid": "org.openmrs.module.uicommons",
+            "version": "2.15.0"
+          },
+           {
+            "uid": "org.openmrs.owa.sysadmin",
+            "version": "1.2"
+          },
+          {
+            "uid": "org.openmrs.module.uiframework",
+            "version": "3.19.0"
+          },
+          {
+            "uid": "org.openmrs.module.uilibrary",
+            "version": "2.0.6"
+          },
+          {
+            "uid": "org.openmrs.module.webservices-rest",
+            "version": "2.29.0"
+          }
+        ]
+      },
     {
       "uid": "refapp_2_9",
       "name": "RefApp 2.9",


### PR DESCRIPTION
https://issues.openmrs.org/browse/AO-26
cc @dkayiwa  
This commit contains two versions of both RefApp 2.10 and RefApp 2.11, i think merging this will override the current commits of refapp 2.10