### PR TITLE
Adding Google Analytics tag to Add Ons webapp

### DIFF
--- a/src/main/ui/index.ejs
+++ b/src/main/ui/index.ejs
@@ -10,6 +10,15 @@
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.min.js"></script>
     <script src="https://unpkg.com/react-router@3.0.2/umd/ReactRouter.min.js"></script>
     <script src="https://use.fontawesome.com/75c2bbc0c8.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-16695719-3"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-16695719-3');
+    </script>
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
### TICKET: 
https://issues.openmrs.org/browse/TRUNK-5985

### SUMMARY:
We want to understand how many people are visiting our Add Ons page, and we have Google Analytics ready-to-go to track this. But it seems like the tag had never been added. This commit adds the tag using the code advised on the Google Analytics settings page shown here: (I didn't write the actual tag code myself, just copy-pasted)
https://analytics.google.com/analytics/web/#/a16695719w36498211p167305509/admin/tracking/tracking-code/

![image](https://user-images.githubusercontent.com/67400059/104783732-8a4e3400-573b-11eb-8e83-5994f51174b3.png)
