### PR TITLE
Publish ohri-core and ohri-reports as OpenMRS addons

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -6653,6 +6653,70 @@
         "groupId": "org.openmrs.module",
         "artifactId": "initializer"
       }
+    },
+    {
+      "uid": "org.openmrs.module.ohri-core",
+      "type": "OMOD",
+      "name": "OHRI Core Module",
+      "maintainers": [
+        {
+          "name": "Arthur D. Mugume"
+        },
+        {
+          "name": "Amos Laboso"
+        },
+        {
+          "name": "Samuel Male"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://github.com/UCSF-IGHS/openmrs-module-ohri-core/blob/master/README.md",
+          "title": "GitHub"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/UCSF-IGHS/openmrs-module-ohri-core"
+        }
+      ],
+      "backend": "org.openmrs.addonindex.backend.Artifactory",
+      "mavenRepoDetails": {
+        "groupId": "org.openmrs.module",
+        "artifactId": "ohri-core"
+      }
+    },
+    {
+      "uid": "org.openmrs.module.ohrireports",
+      "type": "OMOD",
+      "name": "OHRI Reporting Module",
+      "maintainers": [
+        {
+          "name": "Amos Laboso"
+        },
+        {
+          "name": "Arthur D. Mugume"
+        },
+        {
+          "name": "Samuel Male"
+        }
+      ],
+      "links": [
+        {
+          "rel": "documentation",
+          "href": "https://github.com/UCSF-IGHS/openmrs-module-ohri-reports/blob/master/README.md",
+          "title": "GitHub"
+        },
+        {
+          "rel": "source",
+          "href": "https://github.com/UCSF-IGHS/openmrs-module-ohri-reports"
+        }
+      ],
+      "backend": "org.openmrs.addonindex.backend.Artifactory",
+      "mavenRepoDetails": {
+        "groupId": "org.openmrs.module",
+        "artifactId": "ohrireports"
+      }
     }
   ],
   "lists": [


### PR DESCRIPTION
Added Publishing details for the OHRI Core and the OHRI Reporting OpenMRS Modules.


- OHRI Core is an OpenMRS for doing OHRI specific backend tasks such as computed observations etc.
- OHRI Reports is an OpenMRS module for Packaging OHRI Reports powered by the Reporting Module

cc: @alaboso 