### PR TITLE
Modify OHRICore module artifactId to remove 'dash'

### DIFF
--- a/src/main/resources/add-ons-to-index.json
+++ b/src/main/resources/add-ons-to-index.json
@@ -6683,7 +6683,7 @@
       "backend": "org.openmrs.addonindex.backend.Artifactory",
       "mavenRepoDetails": {
         "groupId": "org.openmrs.module",
-        "artifactId": "ohri-core"
+        "artifactId": "ohricore"
       }
     },
     {


### PR DESCRIPTION
Removes 'dash' from module artifactId that was causing publishing issues